### PR TITLE
Add MITRE ATT&CK technique IDs to incident-response skills

### DIFF
--- a/skills/analyzing-campaign-attribution-evidence/SKILL.md
+++ b/skills/analyzing-campaign-attribution-evidence/SKILL.md
@@ -7,6 +7,7 @@ tags: [threat-intelligence, cti, ioc, mitre-attack, stix, attribution, campaign-
 version: "1.0"
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1583, T1584, T1588, T1591]
 ---
 # Analyzing Campaign Attribution Evidence
 

--- a/skills/analyzing-network-traffic-for-incidents/SKILL.md
+++ b/skills/analyzing-network-traffic-for-incidents/SKILL.md
@@ -13,6 +13,7 @@ tags: [network-forensics, PCAP-analysis, Wireshark, Zeek, traffic-analysis]
 version: 1.0.0
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1071, T1095, T1041, T1573, T1572]
 ---
 
 # Analyzing Network Traffic for Incidents

--- a/skills/building-incident-response-dashboard/SKILL.md
+++ b/skills/building-incident-response-dashboard/SKILL.md
@@ -11,6 +11,7 @@ tags: [soc, dashboard, incident-response, splunk, visualization, situational-awa
 version: "1.0"
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1078, T1110, T1190]
 ---
 # Building Incident Response Dashboard
 

--- a/skills/building-incident-response-playbook/SKILL.md
+++ b/skills/building-incident-response-playbook/SKILL.md
@@ -13,6 +13,7 @@ tags: [IR-playbook, runbook, NIST-800-61, SOAR-integration, response-procedures]
 version: 1.0.0
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1059, T1078, T1566, T1486]
 ---
 
 # Building Incident Response Playbooks

--- a/skills/building-incident-timeline-with-timesketch/SKILL.md
+++ b/skills/building-incident-timeline-with-timesketch/SKILL.md
@@ -7,6 +7,7 @@ tags: [timesketch, timeline-analysis, forensic-timeline, plaso, dfir, incident-i
 version: "1.0"
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1070, T1036, T1078, T1059]
 ---
 
 # Building Incident Timeline with Timesketch

--- a/skills/building-malware-incident-communication-template/SKILL.md
+++ b/skills/building-malware-incident-communication-template/SKILL.md
@@ -7,6 +7,7 @@ tags: [incident-communication, malware-response, stakeholder-notification, crisi
 version: "1.0"
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1486, T1566, T1059, T1105]
 ---
 
 # Building Malware Incident Communication Template

--- a/skills/building-patch-tuesday-response-process/SKILL.md
+++ b/skills/building-patch-tuesday-response-process/SKILL.md
@@ -7,6 +7,7 @@ tags: [patch-management, patch-tuesday, microsoft, wsus, sccm, vulnerability-rem
 version: "1.0"
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1190, T1203, T1210, T1068]
 ---
 # Building Patch Tuesday Response Process
 

--- a/skills/collecting-volatile-evidence-from-compromised-host/SKILL.md
+++ b/skills/collecting-volatile-evidence-from-compromised-host/SKILL.md
@@ -7,6 +7,7 @@ tags: [incident-response, dfir, forensics, volatile-evidence, memory-forensics, 
 version: "1.0"
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1003, T1059, T1055, T1070, T1057]
 ---
 
 # Collecting Volatile Evidence from Compromised Hosts

--- a/skills/conducting-cloud-incident-response/SKILL.md
+++ b/skills/conducting-cloud-incident-response/SKILL.md
@@ -12,6 +12,7 @@ tags: [cloud-IR, AWS-forensics, Azure-incident-response, GCP-security, identity-
 version: 1.0.0
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1078, T1537, T1580, T1098, T1530]
 ---
 
 # Conducting Cloud Incident Response

--- a/skills/conducting-malware-incident-response/SKILL.md
+++ b/skills/conducting-malware-incident-response/SKILL.md
@@ -13,6 +13,7 @@ tags: [malware-response, malware-analysis, eradication, endpoint-remediation, MI
 version: 1.0.0
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1059, T1105, T1547, T1055, T1027]
 ---
 
 # Conducting Malware Incident Response

--- a/skills/conducting-phishing-incident-response/SKILL.md
+++ b/skills/conducting-phishing-incident-response/SKILL.md
@@ -13,6 +13,7 @@ tags: [phishing-response, email-security, credential-compromise, email-header-an
 version: 1.0.0
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1566, T1598, T1204, T1078, T1534]
 ---
 
 # Conducting Phishing Incident Response

--- a/skills/conducting-post-incident-lessons-learned/SKILL.md
+++ b/skills/conducting-post-incident-lessons-learned/SKILL.md
@@ -7,6 +7,7 @@ tags: [incident-response, lessons-learned, post-incident, after-action-review, p
 version: "1.0"
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1078, T1059, T1070]
 ---
 
 # Conducting Post-Incident Lessons Learned

--- a/skills/implementing-ot-incident-response-playbook/SKILL.md
+++ b/skills/implementing-ot-incident-response-playbook/SKILL.md
@@ -11,6 +11,7 @@ tags: [ot-security, ics, incident-response, playbook, sans, iec62443, nist, safe
 version: "1.0"
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T0831, T0857, T0816, T0826, T0813]
 ---
 
 # Implementing OT Incident Response Playbook

--- a/skills/implementing-ticketing-system-for-incidents/SKILL.md
+++ b/skills/implementing-ticketing-system-for-incidents/SKILL.md
@@ -11,6 +11,7 @@ tags: [soc, ticketing, servicenow, jira, thehive, incident-management, sla, work
 version: "1.0"
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1078, T1190, T1566]
 ---
 # Implementing Ticketing System for Incidents
 

--- a/skills/investigating-phishing-email-incident/SKILL.md
+++ b/skills/investigating-phishing-email-incident/SKILL.md
@@ -11,6 +11,7 @@ tags: [soc, phishing, incident-response, email-security, splunk, defender, sandb
 version: "1.0"
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1566, T1204, T1534, T1598, T1114]
 ---
 # Investigating Phishing Email Incident
 

--- a/skills/performing-alert-triage-with-elastic-siem/SKILL.md
+++ b/skills/performing-alert-triage-with-elastic-siem/SKILL.md
@@ -7,6 +7,7 @@ tags: [elastic, siem, alert-triage, soc, elastic-security, detection, esql, kiba
 version: "1.0"
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1078, T1110, T1059, T1053]
 ---
 
 # Performing Alert Triage with Elastic SIEM

--- a/skills/performing-cloud-incident-containment-procedures/SKILL.md
+++ b/skills/performing-cloud-incident-containment-procedures/SKILL.md
@@ -7,6 +7,7 @@ tags: [cloud-security, incident-containment, aws, azure, gcp, cloud-forensics, c
 version: "1.0"
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1078, T1537, T1098, T1580, T1530]
 ---
 
 # Performing Cloud Incident Containment Procedures

--- a/skills/performing-malware-triage-with-yara/SKILL.md
+++ b/skills/performing-malware-triage-with-yara/SKILL.md
@@ -12,6 +12,7 @@ tags: [malware, YARA, triage, classification, pattern-matching]
 version: 1.0.0
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1059, T1027, T1105, T1036]
 ---
 
 # Performing Malware Triage with YARA

--- a/skills/performing-ransomware-incident-response/SKILL.md
+++ b/skills/performing-ransomware-incident-response/SKILL.md
@@ -7,6 +7,7 @@ tags: [incident-response, ransomware, dfir, recovery, eradication, encryption]
 version: "1.0"
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1486, T1490, T1489, T1547, T1070]
 ---
 
 # Performing Ransomware Incident Response

--- a/skills/performing-ransomware-response/SKILL.md
+++ b/skills/performing-ransomware-response/SKILL.md
@@ -13,6 +13,7 @@ tags: [ransomware, encryption-recovery, backup-restoration, ransom-negotiation, 
 version: 1.0.0
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1486, T1490, T1489, T1491, T1562]
 ---
 
 # Performing Ransomware Response

--- a/skills/performing-web-application-vulnerability-triage/SKILL.md
+++ b/skills/performing-web-application-vulnerability-triage/SKILL.md
@@ -7,6 +7,7 @@ tags: [web-application, vulnerability-triage, owasp, dast, sast, burp-suite, zap
 version: "1.0"
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1190, T1059, T1189, T1203]
 ---
 
 # Performing Web Application Vulnerability Triage

--- a/skills/triaging-security-incident-with-ir-playbook/SKILL.md
+++ b/skills/triaging-security-incident-with-ir-playbook/SKILL.md
@@ -7,6 +7,7 @@ tags: [incident-response, triage, playbook, severity-classification, soc]
 version: "1.0"
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1078, T1059, T1566, T1190, T1486]
 ---
 
 # Triaging Security Incidents with IR Playbooks

--- a/skills/triaging-security-incident/SKILL.md
+++ b/skills/triaging-security-incident/SKILL.md
@@ -13,6 +13,7 @@ tags: [incident-triage, NIST-800-61, SANS-PICERL, severity-classification, SOC-o
 version: 1.0.0
 author: mahipal
 license: Apache-2.0
+mitre_attack: [T1078, T1059, T1566, T1190, T1486]
 ---
 
 # Triaging Security Incidents


### PR DESCRIPTION
Fixes #1

Added `mitre_attack` field to YAML frontmatter for all 23 incident-response related skills with real MITRE ATT&CK technique IDs mapped to each skill's specific topic area.

### Technique mappings include:
- **Ransomware response** → T1486 (Data Encrypted for Impact), T1490 (Inhibit System Recovery), T1489 (Service Stop)
- **Cloud incident response/containment** → T1078 (Valid Accounts), T1537 (Transfer Data to Cloud Account), T1098 (Account Manipulation), T1530 (Data from Cloud Storage)
- **Volatile evidence collection** → T1003 (OS Credential Dumping), T1059 (Command and Scripting Interpreter), T1055 (Process Injection)
- **Phishing response** → T1566 (Phishing), T1598 (Phishing for Information), T1204 (User Execution)
- **Malware response** → T1105 (Ingress Tool Transfer), T1547 (Boot or Logon Autostart Execution), T1027 (Obfuscated Files)
- **Network traffic analysis** → T1071 (Application Layer Protocol), T1573 (Encrypted Channel), T1041 (Exfiltration Over C2)
- **OT/ICS incident response** → T0831 (Manipulation of Control), T0826 (Loss of Availability)
- **Vulnerability triage** → T1190 (Exploit Public-Facing Application), T1203 (Exploitation for Client Execution)

### Skills updated (23 total):
All skills matching incident-response, containment, evidence collection, and triage subdomains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added MITRE ATT&CK technique mappings to 23 incident response and security operations skills, including campaign attribution, network analysis, playbook development, malware and ransomware response, cloud operations, and threat triage capabilities. This enriches skill documentation with standardized attack technique references for improved framework alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->