### PR TITLE
fix: replace word-split tags with domain-specific cybersecurity tags

### DIFF
--- a/skills/analyzing-azure-activity-logs-for-threats/SKILL.md
+++ b/skills/analyzing-azure-activity-logs-for-threats/SKILL.md
@@ -8,10 +8,12 @@ description: 'Queries Azure Monitor activity logs and sign-in logs via azure-mon
 domain: cybersecurity
 subdomain: security-operations
 tags:
-- analyzing
 - azure
-- activity
-- logs
+- cloud-security
+- azure-monitor
+- kql
+- threat-hunting
+- activity-logs
 version: '1.0'
 author: mahipal
 license: Apache-2.0

--- a/skills/analyzing-memory-forensics-with-lime-and-volatility/SKILL.md
+++ b/skills/analyzing-memory-forensics-with-lime-and-volatility/SKILL.md
@@ -8,10 +8,12 @@ description: 'Performs Linux memory acquisition using LiME (Linux Memory Extract
 domain: cybersecurity
 subdomain: security-operations
 tags:
-- analyzing
-- memory
-- forensics
-- with
+- memory-forensics
+- linux-forensics
+- lime
+- volatility
+- incident-response
+- kernel-modules
 version: '1.0'
 author: mahipal
 license: Apache-2.0

--- a/skills/analyzing-powershell-script-block-logging/SKILL.md
+++ b/skills/analyzing-powershell-script-block-logging/SKILL.md
@@ -6,10 +6,12 @@ description: Parse Windows PowerShell Script Block Logs (Event ID 4104) from EVT
 domain: cybersecurity
 subdomain: security-operations
 tags:
-- analyzing
 - powershell
-- script
-- block
+- script-block-logging
+- event-id-4104
+- obfuscation-detection
+- windows-forensics
+- endpoint-security
 version: '1.0'
 author: mahipal
 license: Apache-2.0


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Three `SKILL.md` files have `tags:` frontmatter values that are simply words split from the skill filename rather than meaningful cybersecurity discovery keywords:

| File | Bad tags |
|------|----------|
| `analyzing-powershell-script-block-logging` | `[analyzing, powershell, script, block]` |
| `analyzing-azure-activity-logs-for-threats` | `[analyzing, azure, activity, logs]` |
| `analyzing-memory-forensics-with-lime-and-volatility` | `[analyzing, memory, forensics, with]` |

Tags like `analyzing`, `block`, `with`, and `logs` have no discovery value — they match unrelated skills and dilute search results when agents or tooling route based on tags.

## Fix

Replace the word-split tags with domain-specific terms that accurately describe what each skill covers:

| File | New tags |
|------|----------|
| `analyzing-powershell-script-block-logging` | `[powershell, script-block-logging, event-id-4104, obfuscation-detection, windows-forensics, endpoint-security]` |
| `analyzing-azure-activity-logs-for-threats` | `[azure, cloud-security, azure-monitor, kql, threat-hunting, activity-logs]` |
| `analyzing-memory-forensics-with-lime-and-volatility` | `[memory-forensics, linux-forensics, lime, volatility, incident-response, kernel-modules]` |

These tags follow the same conventions used in the high-quality 95-point skills in this repo (e.g., `analyzing-memory-dumps-with-volatility` uses `[malware, memory-forensics, Volatility, RAM-analysis, incident-response]`).

No other changes were made to these files.