### PR TITLE
Fix description YAML for Objection iOS skill

### DIFF
--- a/skills/analyzing-ios-app-security-with-objection/SKILL.md
+++ b/skills/analyzing-ios-app-security-with-objection/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: analyzing-ios-app-security-with-objection
-description: 'Performs runtime mobile security exploration of iOS applications using Objection, a Frida-powered toolkit that
-  enables security testers to interact with app internals without jailbreaking. Use when assessing iOS app security posture,
-  bypassing client-side protections, dumping keychain items, inspecting filesystem storage, and evaluating runtime behavior.
-  Activates for requests involving iOS security testing, Objection runtime analysis, Frida-based iOS assessment, or mobile
-  runtime exploration.
-
-  '
+description: >-
+  Runtime iOS app security testing with Objection (Frida): inspect keychain and
+  filesystem data, explore app internals at runtime, and validate/bypass
+  client-side protections during authorized mobile assessments.
 domain: cybersecurity
 subdomain: mobile-security
 author: mahipal


### PR DESCRIPTION
This updates the `description` frontmatter for `analyzing-ios-app-security-with-objection` to use a standard YAML folded scalar.

Why:
- Some tooling treats multi-line single-quoted strings (especially with trailing whitespace) as missing/invalid metadata.
- This should make the skill’s description reliably discoverable by external indexers.

Closes #31.