### PR TITLE
Add 2 skills: deception (MITRE Engage, cloud decoys)

### DIFF
--- a/skills/deploying-cloud-deception-with-decoy-resources/LICENSE
+++ b/skills/deploying-cloud-deception-with-decoy-resources/LICENSE
@@ -1,0 +1,201 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. Please do not remove or change
+      the license header comment from a contributed file except when
+      necessary.
+
+   Copyright 2026 mukul975
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/deploying-cloud-deception-with-decoy-resources/SKILL.md
+++ b/skills/deploying-cloud-deception-with-decoy-resources/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: deploying-cloud-deception-with-decoy-resources
+description: >-
+  Deploy cloud-native deception across AWS, Azure, and GCP using decoy (honey) resources
+  whose only purpose is to generate a high-fidelity alert the instant an attacker touches
+  them: canary IAM access keys, permission-less decoy users/roles/service principals,
+  honey object-storage buckets, and decoy secrets in Secrets Manager / Key Vault / Secret
+  Manager. Wires detection through CloudTrail + EventBridge, Azure Sentinel honeytoken
+  watchlists + Defender, and GCP Cloud Audit Logs, so any use of a decoy is routed to the
+  SOC with near-zero false positives. Use when protecting cloud accounts and data stores,
+  when an org has only on-prem honeypots and needs cloud coverage, when seeding fake AWS
+  keys to catch credential theft and code-leak exposure, or when detecting cloud
+  reconnaissance and lateral movement. Keywords: cloud deception, canary token AWS, honey
+  S3 bucket, decoy IAM credentials, CloudTrail alert, GuardDuty, Sentinel honeytoken,
+  decoy secret, honey service account, cloud honeypot, breach detection.
+domain: cybersecurity
+subdomain: deception-technology
+tags:
+- cloud-deception
+- aws
+- azure
+- gcp
+- canary-token
+- honeytoken
+- cloudtrail
+- breach-detection
+version: "1.0"
+author: andrewibrah
+license: Apache-2.0
+nist_csf:
+- DE.CM-01
+- DE.CM-06
+- DE.AE-02
+- ID.RA-01
+- RS.MA-01
+mitre_attack:
+- T1078
+- T1552
+- T1580
+- T1530
+- T1619
+---
+
+# Deploying Cloud Deception with Decoy Resources
+
+## When to Use
+
+- When cloud accounts (AWS/Azure/GCP) hold crown-jewel data or infrastructure and you need a tripwire that fires the moment an attacker who has gained access starts to operate.
+- When the only deception in place is on-prem honeypots, leaving the cloud control plane uninstrumented.
+- When seeding fake credentials to catch credential theft, accidental code-repo leaks, or secrets exposed in build pipelines.
+- When detecting cloud reconnaissance (enumeration of IAM, storage, or secrets) and lateral movement that legitimate users would never perform.
+- When you want detections that survive into incident response with strong fidelity — a touch on a decoy resource almost always means malicious or unauthorized activity.
+
+This is the cloud counterpart to on-prem honeypot/honeytoken/canary-token deployment skills. For program strategy and how these Activities map to adversary engagement goals, use `designing-adversary-engagement-with-mitre-engage`.
+
+## Prerequisites
+
+- Cloud admin/IAM permissions to create decoy principals, storage, secrets, and detection wiring, ideally in a dedicated deployment role with least privilege.
+- Cloud audit logging already enabled: **AWS CloudTrail** (multi-region, with management and relevant data events), **Azure Activity log + Microsoft Entra audit/sign-in logs**, **GCP Cloud Audit Logs (Admin Activity always on; Data Access enabled where needed)**.
+- A SIEM/alert sink: SNS topic, Microsoft Sentinel workspace, or GCP Pub/Sub + Monitoring, with routing to the SOC.
+- A naming and tagging convention that is plausible to an attacker but unambiguous to defenders internally (e.g., realistic names, plus an internal `deception=true` tag/label kept out of attacker-visible metadata).
+- **Decoy principals must be permission-less (explicit deny-all).** The value is the alert, never the access. A decoy that grants real privilege is a liability, not a control.
+
+## Workflow
+
+### 1. Decide what to mimic
+Pick decoys that match how *your* attackers operate: leaked AWS keys (credential theft), an "admin" S3 bucket (data discovery), a `prod-db-password` secret (secrets harvesting), a privileged-looking service account (cloud lateral movement). Place credential decoys where harvesting tools look: env files, CI variables, code comments, an internal wiki.
+
+### 2A. AWS — canary access keys on a permission-less user
+Create a decoy IAM user with an explicit deny-all policy, then issue an access key to plant:
+```bash
+aws iam create-user --user-name svc-backup-prod --tags Key=deception,Value=true
+aws iam put-user-policy --user-name svc-backup-prod \
+  --policy-name deny-all \
+  --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"*","Resource":"*"}]}'
+aws iam create-access-key --user-name svc-backup-prod   # plant the returned AccessKeyId/Secret
+```
+Any use of this key appears in CloudTrail (even denied calls, which still log `AccessDenied`). Wire an EventBridge rule on CloudTrail to alert:
+```bash
+aws events put-rule --name decoy-key-used \
+  --event-pattern '{"detail":{"userIdentity":{"userName":["svc-backup-prod"]}}}'
+aws events put-targets --rule decoy-key-used \
+  --targets "Id"="1","Arn"="arn:aws:sns:us-east-1:111111111111:soc-deception-alerts"
+```
+
+### 2B. AWS — honey S3 bucket
+Create a believable bucket, enable object-level data events, and alert on any read/list:
+```bash
+aws s3api create-bucket --bucket acme-prod-db-backups-2026 --region us-east-1
+aws s3api put-bucket-tagging --bucket acme-prod-db-backups-2026 \
+  --tagging 'TagSet=[{Key=deception,Value=true}]'
+# Ensure CloudTrail captures S3 data events for this bucket, then alert on GetObject/ListBucket
+aws events put-rule --name decoy-bucket-access \
+  --event-pattern '{"detail":{"eventSource":["s3.amazonaws.com"],"requestParameters":{"bucketName":["acme-prod-db-backups-2026"]}}}'
+```
+
+### 2C. AWS — decoy secret
+```bash
+aws secretsmanager create-secret --name prod/db/master-password \
+  --secret-string '{"username":"dbadmin","password":"DECOY-DO-NOT-USE"}' \
+  --tags Key=deception,Value=true
+# Alert on GetSecretValue for this secret via EventBridge -> SNS
+```
+
+### 3A. Azure — honeytoken watchlist + decoy service principal
+Microsoft Sentinel natively supports honeytokens via a **Watchlist** of the `HoneyTokens` template; tagged decoy accounts/secrets raise analytics alerts on use. Create a permission-less decoy app registration / service principal, then add its identifiers to the HoneyTokens watchlist and enable the related analytics rules. Microsoft Defender for Cloud and Entra ID Protection surface anomalous sign-ins to the decoy identity.
+
+### 3B. Azure — honey storage + Key Vault decoy secret
+Create a decoy Storage account and Key Vault, enable diagnostic logging to the Sentinel workspace, store a decoy secret, and write an analytics rule that fires on any data-plane read of the decoy resources.
+
+### 4A. GCP — decoy service account + honey GCS bucket
+Create a service account with no role bindings (permission-less), generate a key to plant, and alert on its use via Cloud Audit Logs:
+```bash
+gcloud iam service-accounts create svc-billing-export \
+  --display-name="billing-export"
+gcloud iam service-accounts keys create decoy-key.json \
+  --iam-account=svc-billing-export@PROJECT.iam.gserviceaccount.com   # plant this key
+gsutil mb -b on gs://acme-finance-exports-2026
+```
+Create a log-based metric + alerting policy in Cloud Monitoring that triggers on any audit-log entry where the principal is the decoy service account or the resource is the honey bucket.
+
+### 5. Centralize and de-duplicate
+Route all clouds' decoy alerts to one SOC pipeline. Tag each alert as DECEPTION/high-fidelity so it bypasses normal noise filtering and triggers an IR playbook rather than a triage queue.
+
+### 6. Validate (red-team the decoys)
+Have an authorized tester use each decoy (read the bucket, call with the key, fetch the secret) and confirm an alert lands end-to-end within target latency. A decoy you have not tested is assumed broken.
+
+### 7. Maintain realism and rotate
+Refresh decoy names, secrets, and pocket-litter periodically so they age with the real environment. Track every decoy in an inventory so they are never mistaken for real assets during audits or cleanups.
+
+## Key Concepts
+
+| Concept | Definition |
+|---|---|
+| Decoy / honey resource | A cloud object created solely to be touched by an attacker; no legitimate user has any reason to use it. |
+| Canary access key | A planted credential whose use generates an audit-log event; carries deny-all permissions. |
+| High-fidelity alert | A near-zero-false-positive signal because legitimate workflows never reference the decoy. |
+| Permission-less principal | A decoy IAM user/role/service principal/service account with explicit deny-all or no role bindings. |
+| Data event | Cloud audit logging of object/data-plane access (e.g., S3 GetObject), required to detect storage decoys. |
+| Pocket litter | Plausible supporting artifacts (fake configs, env files, wiki entries) that make a decoy credible. |
+| Decoy inventory | The authoritative internal record distinguishing decoys from real assets. |
+
+## Tools & Systems
+
+- **AWS** — IAM (decoy users/roles), S3 (honey buckets, data events), Secrets Manager / SSM Parameter Store (decoy secrets), CloudTrail, EventBridge, SNS/Lambda, GuardDuty (correlate anomalous use).
+- **Azure** — Microsoft Entra ID (decoy app registrations / service principals), Storage / Key Vault decoys, **Microsoft Sentinel HoneyTokens watchlist** and analytics rules, Microsoft Defender for Cloud, Entra ID Protection.
+- **GCP** — IAM service accounts (decoys), Cloud Storage (honey buckets), Secret Manager (decoy secrets), Cloud Audit Logs, log-based metrics + Cloud Monitoring alerting, Pub/Sub.
+- **Open-source / managed honeytoken systems** — Canarytokens (https://canarytokens.org offers AWS API key tokens), Thinkst Canary, SpaceSiren / SpaceCrab (self-hosted AWS honey-token frameworks).
+- **SIEM/SOAR** — to centralize alerts across clouds and drive an IR playbook on any decoy hit.
+
+## Common Scenarios
+
+- **Credential-theft / code-leak detection.** Plant a canary AWS key in CI variables, an env file, and a private repo. Any external use (even from a leaked public push) fires within minutes.
+- **Crown-jewel data store.** Stand up a honey "backups" bucket next to the real one; attackers enumerating storage hit the decoy first and reveal themselves.
+- **Cloud lateral movement.** A permission-less decoy service principal that "looks" privileged catches adversaries assuming roles during pivoting.
+- **Secrets harvesting.** Decoy entries in Secrets Manager / Key Vault / Secret Manager detect tools scraping the secrets store.
+- **Migrating from on-prem-only deception.** Mirror the existing on-prem decoy strategy into the cloud control plane so coverage follows workloads.
+
+## Output Format
+
+Produce a **Cloud Deception Deployment Record** using `assets/template.md`, containing:
+
+1. **Decoy inventory** — per decoy: cloud, type, plausible name, real placement location of any planted credential, internal `deception` tag/label, owner.
+2. **Detection wiring** — per decoy: audit-log source → rule/pattern → alert sink → IR playbook reference, with the target alert latency.
+3. **Least-privilege proof** — evidence each decoy principal is deny-all / no-role-binding.
+4. **Validation results** — date tested, who tested, end-to-end latency observed, pass/fail.
+5. **Maintenance plan** — rotation cadence and review owner.
+
+Use `scripts/process.py` to render the deployment record and a per-decoy detection checklist from a decoy-inventory JSON, and to flag decoys missing detection wiring or validation.

--- a/skills/deploying-cloud-deception-with-decoy-resources/assets/template.md
+++ b/skills/deploying-cloud-deception-with-decoy-resources/assets/template.md
@@ -1,0 +1,33 @@
+# Cloud Deception Deployment Record
+
+> Worked example. Keep this record internal and separate from any attacker-visible metadata.
+
+**Account / project:** acme-prod (AWS 111111111111) · **Owner:** [Cloud security lead] · **Last validated:** 2026-05-20
+
+## 1. Decoy inventory & detection wiring
+| Decoy | Cloud | Type | Plausible placement | Detection: source → rule → sink → playbook | Deny-all? | Target latency |
+|---|---|---|---|---|---|---|
+| svc-backup-prod (key) | AWS | Canary access key | CI variables, repo `.env`, internal wiki | CloudTrail → `decoy-key-used` → `sns:soc-deception-alerts` → IR-CLOUD-07 | Yes | < 5 min |
+| acme-prod-db-backups-2026 | AWS | Honey S3 bucket | Discoverable via S3 list | CloudTrail data events → `decoy-bucket-access` → SNS → IR-CLOUD-07 | n/a | < 5 min |
+| prod/db/master-password | AWS | Decoy secret | Secrets Manager | CloudTrail `GetSecretValue` → `decoy-secret-read` → SNS → IR-CLOUD-07 | n/a | < 5 min |
+| h* sentinel honeytoken acct | Azure | Decoy service principal | Entra app registration | Sentinel HoneyTokens watchlist → analytics rule → SOC → IR-CLOUD-07 | Yes (no roles) | < 10 min |
+| svc-billing-export | GCP | Decoy service account key | Build config | Cloud Audit Logs → log-based metric → Monitoring alert → IR-CLOUD-07 | Yes (no bindings) | < 10 min |
+
+## 2. Least-privilege proof
+- AWS decoy users: explicit `Deny *` inline policy attached (`deny-all`); verified with `aws iam get-user-policy`.
+- Azure decoy SP: zero role assignments; verified in Entra.
+- GCP decoy SA: zero IAM policy bindings; verified with `gcloud iam service-accounts get-iam-policy`.
+
+## 3. Validation results (red-team each decoy)
+| Decoy | Tested | By | Observed latency | Pass/Fail |
+|---|---|---|---|---|
+| svc-backup-prod | 2026-05-20 | Red team | 90 s | PASS |
+| acme-prod-db-backups-2026 | 2026-05-20 | Red team | 2 min | PASS |
+| prod/db/master-password | 2026-05-20 | Red team | 75 s | PASS |
+| Azure honeytoken SP | 2026-05-20 | Red team | 6 min | PASS |
+| svc-billing-export | 2026-05-20 | Red team | 4 min | PASS |
+
+## 4. Maintenance plan
+- **Rotation cadence:** Refresh names/secrets/pocket-litter quarterly so decoys age with prod.
+- **Review owner:** [Cloud security lead], quarterly.
+- **Inventory rule:** No decoy is deleted during clean-ups/audits without confirming against this record.

--- a/skills/deploying-cloud-deception-with-decoy-resources/references/standards.md
+++ b/skills/deploying-cloud-deception-with-decoy-resources/references/standards.md
@@ -1,0 +1,62 @@
+# Cloud Deception — Standards & Reference
+
+## Detection foundations (audit logging is mandatory)
+Cloud deception only works if a decoy touch is logged. Confirm these before deploying.
+
+### AWS
+- **CloudTrail** — management events plus **data events** (S3 object-level, Lambda invoke, etc.) for any storage/secret decoys. Multi-region trail recommended.
+- **EventBridge** — pattern-match CloudTrail events on `userIdentity.userName`, `eventSource`, or `requestParameters.bucketName` and target SNS/Lambda.
+- **GuardDuty** — correlates anomalous credential/API behavior; useful to enrich a decoy hit.
+- Note: even *denied* API calls by a deny-all decoy principal are recorded in CloudTrail as `AccessDenied`, so the alert fires regardless of granted permission.
+
+### Azure / Microsoft
+- **Azure Activity log** + **Microsoft Entra ID audit and sign-in logs** streamed to a Log Analytics / Microsoft Sentinel workspace.
+- **Microsoft Sentinel HoneyTokens** — built-in watchlist template; decoy identifiers added to the watchlist drive analytics rules that alert on use.
+- **Microsoft Defender for Cloud** and **Entra ID Protection** — surface anomalous access to decoy identities.
+- Enable diagnostic settings on decoy Storage accounts and Key Vaults to capture data-plane reads.
+
+### GCP
+- **Cloud Audit Logs** — Admin Activity logs are always on; enable **Data Access** logs for the services hosting decoys (Cloud Storage, Secret Manager, IAM).
+- **Log-based metrics + Cloud Monitoring alerting policies** — trigger on audit entries where `protoPayload.authenticationInfo.principalEmail` is the decoy service account or the resource is the honey bucket.
+- **Pub/Sub** sink to forward to a SIEM.
+
+## MITRE D3FEND — Deceive tactic mappings
+| D3FEND technique | Cloud decoy realization |
+|---|---|
+| Decoy User Credential | Canary IAM access key / decoy app secret / decoy SA key |
+| Decoy Network Resource | Honey S3 / GCS / Azure Storage bucket |
+| Decoy Object | Decoy secret in Secrets Manager / Key Vault / Secret Manager |
+| Decoy Persona | Permission-less decoy IAM user / service principal / service account |
+| Decoy Session Token | Planted temporary credential / SAS token |
+
+## MITRE ATT&CK techniques detected
+| Technique | Detected by decoy |
+|---|---|
+| T1078 / T1078.004 Valid Accounts (Cloud) | Canary key / decoy principal use |
+| T1552 / T1552.001 Unsecured Credentials | Decoy secret read; planted credential use |
+| T1580 Cloud Infrastructure Discovery | Enumeration touching decoy principals/resources |
+| T1619 Cloud Storage Object Discovery | List on honey bucket |
+| T1530 Data from Cloud Storage Object | GetObject on honey bucket |
+
+## NIST CSF 2.0 alignment
+| CSF 2.0 ID | Relevance |
+|---|---|
+| DE.CM-01 | Networks/environments monitored to find adverse events |
+| DE.CM-06 | External service provider (cloud) activity monitored |
+| DE.AE-02 | Potentially adverse events analyzed — decoy alert triage |
+| ID.RA-01 | Vulnerabilities/exposures identified — informs decoy placement |
+| RS.MA-01 | Incident management — decoy hit invokes the IR playbook |
+
+## Tooling references
+- Canarytokens (AWS API key token): https://canarytokens.org
+- Thinkst Canary: https://canary.tools
+- SpaceSiren (self-hosted AWS honey tokens, serverless): open-source
+- Microsoft Sentinel HoneyTokens watchlist: Microsoft Learn — "Deploy decoys/honeytokens with Sentinel"
+- AWS CloudTrail data events: AWS docs — "Logging data events"
+- GCP Cloud Audit Logs: Google Cloud docs — "Cloud Audit Logs overview"
+
+## Operating principles
+- **Deny-all decoys only.** Decoy principals must carry an explicit deny-all policy (AWS) or no role bindings (GCP) / no privileged roles (Azure). The control's value is the alert, never access.
+- **Keep an internal decoy inventory** separate from attacker-visible metadata so audits and clean-ups never delete a tripwire by accident, and real assets are never mistaken for decoys.
+- **Validate end-to-end** (red-team each decoy) and record observed alert latency. Untested decoys are assumed non-functional.
+- **Mark deception alerts high-fidelity** so they bypass routine noise filtering and go straight to an IR playbook.

--- a/skills/deploying-cloud-deception-with-decoy-resources/scripts/process.py
+++ b/skills/deploying-cloud-deception-with-decoy-resources/scripts/process.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Cloud deception deployment validator.
+
+Reads a decoy-inventory JSON, checks each decoy for the controls that make a
+cloud decoy trustworthy (detection wiring, deny-all/least-privilege, validation,
+internal tagging), renders a Cloud Deception Deployment Record, and exits non-zero
+if any decoy is missing a required control.
+
+Usage:
+    python process.py --inventory decoys.json --out record.md
+
+decoys.json format:
+    {
+      "account": "acme-prod (AWS 1111...)",
+      "decoys": [
+        {
+          "name": "svc-backup-prod",
+          "cloud": "aws",
+          "type": "canary_access_key",
+          "placement": "CI variables + private repo .env",
+          "deny_all": true,
+          "detection": {"source": "CloudTrail", "rule": "decoy-key-used", "sink": "sns:soc-deception-alerts", "playbook": "IR-CLOUD-07"},
+          "validated": {"date": "2026-05-20", "by": "redteam", "latency_sec": 90, "passed": true},
+          "internal_tag": "deception=true"
+        }
+      ]
+    }
+"""
+import argparse
+import json
+import sys
+from datetime import date
+
+REQUIRED = ["name", "cloud", "type", "placement"]
+VALID_CLOUDS = {"aws", "azure", "gcp"}
+
+
+def check_decoy(d):
+    """Return list of issues for one decoy."""
+    issues = []
+    for k in REQUIRED:
+        if not d.get(k):
+            issues.append(f"missing required field '{k}'")
+    if d.get("cloud") and d["cloud"].lower() not in VALID_CLOUDS:
+        issues.append(f"unknown cloud '{d.get('cloud')}'")
+
+    det = d.get("detection") or {}
+    for k in ("source", "rule", "sink"):
+        if not det.get(k):
+            issues.append(f"detection wiring missing '{k}' (decoy is blind)")
+    if not det.get("playbook"):
+        issues.append("no IR playbook reference for the alert")
+
+    # Credential/principal decoys must be deny-all / least privilege.
+    cred_types = {"canary_access_key", "decoy_principal", "decoy_service_account",
+                  "decoy_service_principal", "decoy_iam_user"}
+    if d.get("type") in cred_types and not d.get("deny_all"):
+        issues.append("credential/principal decoy is not marked deny_all (liability risk)")
+
+    val = d.get("validated") or {}
+    if not val.get("passed"):
+        issues.append("not validated end-to-end (assume non-functional)")
+    if not d.get("internal_tag"):
+        issues.append("no internal deception tag/label (audit-cleanup risk)")
+    return issues
+
+
+def render(inv, results):
+    lines = [f"# Cloud Deception Deployment Record",
+             f"\n_Account: {inv.get('account', 'UNKNOWN')} — generated {date.today().isoformat()}_\n",
+             "## 1. Decoy inventory & detection wiring",
+             "| Decoy | Cloud | Type | Placement | Detection (source→rule→sink) | Playbook | Validated | Status |",
+             "|---|---|---|---|---|---|---|---|"]
+    for d, issues in results:
+        det = d.get("detection") or {}
+        wiring = f"{det.get('source','?')}→{det.get('rule','?')}→{det.get('sink','?')}"
+        val = d.get("validated") or {}
+        vstr = f"{val.get('date','-')} ({val.get('latency_sec','?')}s)" if val.get("passed") else "NO"
+        status = "OK" if not issues else f"{len(issues)} issue(s)"
+        lines.append(f"| {d.get('name','?')} | {d.get('cloud','?')} | {d.get('type','?')} | "
+                     f"{d.get('placement','?')} | {wiring} | {det.get('playbook','-')} | {vstr} | {status} |")
+
+    problem = [(d, i) for d, i in results if i]
+    if problem:
+        lines.append("\n## 2. Issues to remediate before relying on these decoys")
+        for d, issues in problem:
+            lines.append(f"\n**{d.get('name','?')}** ({d.get('cloud','?')}):")
+            for it in issues:
+                lines.append(f"- {it}")
+    else:
+        lines.append("\n## 2. Issues\nNone — all decoys have detection wiring, least privilege, and validation.")
+
+    lines.append("\n## 3. Maintenance")
+    lines.append("- Rotation cadence: TBD  ·  Review owner: TBD")
+    lines.append("- Keep this record separate from attacker-visible metadata.")
+    return "\n".join(lines)
+
+
+def main():
+    p = argparse.ArgumentParser(description="Cloud deception deployment validator")
+    p.add_argument("--inventory", required=True, help="Path to decoy-inventory JSON")
+    p.add_argument("--out", help="Output markdown path (default: stdout)")
+    args = p.parse_args()
+
+    with open(args.inventory) as f:
+        inv = json.load(f)
+
+    decoys = inv.get("decoys", [])
+    results = [(d, check_decoy(d)) for d in decoys]
+    total_issues = sum(len(i) for _, i in results)
+    healthy = sum(1 for _, i in results if not i)
+
+    print(f"{len(decoys)} decoy(s): {healthy} healthy, {total_issues} total issue(s).",
+          file=sys.stderr)
+
+    out = render(inv, results)
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(out + "\n")
+        print(f"Wrote deployment record -> {args.out}", file=sys.stderr)
+    else:
+        print(out)
+
+    # Non-zero exit if any decoy has issues, so this can gate a pipeline.
+    sys.exit(1 if total_issues else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/designing-adversary-engagement-with-mitre-engage/LICENSE
+++ b/skills/designing-adversary-engagement-with-mitre-engage/LICENSE
@@ -1,0 +1,201 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. Please do not remove or change
+      the license header comment from a contributed file except when
+      necessary.
+
+   Copyright 2026 mukul975
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/designing-adversary-engagement-with-mitre-engage/SKILL.md
+++ b/skills/designing-adversary-engagement-with-mitre-engage/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: designing-adversary-engagement-with-mitre-engage
+description: >-
+  Plan, run, and measure an adversary engagement operation using the MITRE Engage
+  framework so that deployed deception is driven by strategy instead of deployed ad hoc.
+  Covers the Engage Matrix (Prepare, Expose, Affect, Elicit, Understand), the 10-Step
+  Operational Process, mapping engagement Activities to the ATT&CK techniques they
+  expose, and defining measurable Goals and Operational Objectives. Use when a team has
+  honeypots, honeytokens, or canary tokens but no coordinating strategy, when leadership
+  asks "should we engage attackers and how", when building a deception/denial program,
+  when writing an adversary engagement operation plan, or when deciding which deception
+  Activities to deploy against a specific threat actor. Keywords: MITRE Engage, adversary
+  engagement, cyber deception strategy, denial and deception, Engage Matrix, EAC, EGO,
+  Expose Affect Elicit, deception program, honeypot strategy, engagement operation.
+domain: cybersecurity
+subdomain: deception-technology
+tags:
+- mitre-engage
+- adversary-engagement
+- deception
+- denial-and-deception
+- engage-matrix
+- cyber-deception
+- threat-intelligence
+- detection-engineering
+version: "1.0"
+author: andrewibrah
+license: Apache-2.0
+nist_csf:
+- GV.RM-01
+- ID.RA-01
+- ID.IM-02
+- DE.CM-01
+- DE.AE-02
+mitre_attack:
+- T1078
+- T1083
+- T1021
+- T1552
+- T1046
+---
+
+# Designing Adversary Engagement with MITRE Engage
+
+## When to Use
+
+- When an organization owns deception tooling (honeypots, honeytokens, canary tokens, decoy files) but deploys it tactically with no unifying strategy or measurable outcome.
+- When leadership asks whether the organization *should* engage adversaries, and what the legal, operational, and resourcing implications are.
+- When writing a formal adversary engagement operation plan that must justify every deployed deceptive artifact against a strategic goal.
+- When selecting which specific deception Activities to deploy against a known or suspected threat actor based on that actor's ATT&CK TTPs.
+- When building a denial, deception, and adversary engagement (DD&AE) program that must integrate with existing SOC, threat intel, and incident response functions.
+- When a deception deployment generates alerts that nobody knows how to act on, because Expose was never connected to Affect or Elicit goals.
+
+This skill is the **strategy and operations layer** that sits above tactical deployment skills (honeypot, honeytoken, canary-token, and decoy-file deployment). Use those skills to *implement* the Activities this skill selects and sequences.
+
+## Prerequisites
+
+- Familiarity with MITRE ATT&CK (tactics, techniques, and how to read a technique page), because Engagement Activities are mapped to the ATT&CK techniques they expose.
+- A documented set of critical assets and an understanding of which adversaries plausibly target them (a threat model or prioritized threat actor list).
+- Executive sponsorship and a written legal review. Engagement operations interact with live adversaries and raise entrapment, evidence-handling, and liability questions; **never run an engagement operation without legal sign-off.**
+- An existing detection and response capability. Engage is an additive strategy, not a replacement for defense-in-depth; if a defense-in-depth control fails, engagement keeps you in control rather than blind.
+- Access to the live matrix at https://engage.mitre.org/matrix/ for canonical Activity names and IDs.
+
+## Workflow
+
+Engage operations follow the **10-Step Operational Process**. The matrix is linear to read but cyclical to run — you continuously realign Activities toward your Goals as the adversary reacts.
+
+### 1. Confirm strategic fit (Prepare)
+Decide where denial, deception, and adversary engagement fit in the existing cyber strategy. The `Prepare` goal (a strategic bookend, alongside `Understand`) defines the inputs to the operation. Document the strategic goal in plain language, e.g. "reduce dwell time of insider threats around the source-code repository" or "generate first-party CTI on the actor targeting our VPN."
+
+### 2. Define Engagement Goals and Operational Objectives
+Select from the three Engagement Goals. Goals set direction; **Operational Objectives** take measurable steps in that direction.
+
+| Engagement Goal (EGO) | What it does | Example Operational Objective |
+|---|---|---|
+| Expose | Reveal adversary presence with high-fidelity, low-false-positive alerts | "Alert within 5 minutes of any touch on a decoy credential" |
+| Affect | Negatively change the adversary's cost-value calculation (defender network only) | "Redirect the adversary away from 3 unpatchable legacy hosts" |
+| Elicit | Observe the adversary to learn TTPs and produce CTI | "Obtain a second-stage malware sample" or "identify ≥10 new indicators" |
+
+Write objectives as falsifiable, time-bound statements. A goal without an objective is unmeasurable.
+
+### 3. Build the threat model and select Approaches
+For each Goal, pick the Engagement Approaches (EAP) that fit the adversary you modeled:
+
+- **Expose** → Collection, Detection
+- **Affect** → Prevention, Direction, Disruption
+- **Elicit** → Reassurance, Motivation
+
+### 4. Map ATT&CK techniques to Engagement Activities
+For each technique your target adversary uses, find the Engage Activity that exposes the weakness that technique creates. Example mappings:
+
+| Adversary technique (ATT&CK) | Weakness exposed | Engage Activity (EAC) |
+|---|---|---|
+| T1078 Valid Accounts | Must test credentials | Decoy Credentials, Lures |
+| T1083 File & Directory Discovery | Must enumerate files | Decoy Content, Pocket Litter |
+| T1046 Network Service Discovery | Must scan the network | Network Diversity, Decoy Systems |
+| T1021 Remote Services | Must move laterally | Decoy Systems, Network Manipulation |
+| T1552 Unsecured Credentials | Harvests secrets | Decoy Credentials, Artifact Diversity |
+
+Pull the authoritative Activity list and IDs from the live matrix; Engage IDs use the prefixes **SGO/EGO** (Goals), **SAP/EAP** (Approaches), and **SAC/EAC** (Activities).
+
+### 5. Design the engagement environment
+Decide realism and isolation. Choose between standalone, connected, or integrated decoy environments (see D3FEND honeynet types in `references/standards.md`). Populate it with diverse, believable artifacts — Persona Creation, Pocket Litter, Artifact Diversity, Application Diversity — so the environment survives adversary scrutiny.
+
+### 6. Define gating criteria and rules of engagement
+Document, before deployment: what the adversary is allowed to reach, the maximum blast radius, the trigger for tear-down or hand-off to IR, evidence preservation steps, and who has authority to escalate. **Affect Activities are limited to the defender's own network** — never act on infrastructure you do not own.
+
+### 7. Deploy the Activities
+Implement the selected Activities using the tactical deployment skills (honeypots, honeytokens, canary tokens, decoy files). Instrument every artifact so a touch produces telemetry routed to the SOC.
+
+### 8. Operate and observe
+Run the operation. Triage Expose alerts as high-fidelity (a touch on a decoy almost always means malicious or unauthorized activity). Feed observations back into Approach selection — realign Affect/Elicit Activities as the adversary behaves.
+
+### 9. Analyze (Understand)
+The `Understand` goal (the output bookend) turns observations into decisions: new detections for production, CTI for sharing, and validated or invalidated threat-model assumptions.
+
+### 10. After-action and feedback
+Score the operation against the Operational Objectives from Step 2. Capture what intel was gained, what Activities triggered, dwell time, and lessons learned. Update the threat model and feed the next cycle.
+
+## Key Concepts
+
+| Concept | Definition |
+|---|---|
+| Goal (SGO/EGO) | High-level outcome of the operation. Prepare/Understand are strategic bookends; Expose/Affect/Elicit are the engagement goals. |
+| Approach (SAP/EAP) | The method used to make progress toward a Goal (e.g., Detection, Direction, Motivation). |
+| Activity (SAC/EAC) | The concrete denial/deception action deployed (e.g., Decoy Credentials, Network Manipulation). |
+| Operate | The default matrix view = Expose + Affect + Elicit, the three engagement goals. |
+| Operational Objective | A measurable, time-bound target that operationalizes a Goal. |
+| Gating Criteria | Pre-defined boundaries and triggers that constrain the operation's blast radius. |
+| High-fidelity alert | An alert from a decoy that legitimate users have no reason to touch, yielding near-zero false positives. |
+| Denial vs. Deception | Denial blocks the adversary's access to real information; deception feeds plausible false information. |
+
+## Tools & Systems
+
+- **MITRE Engage Matrix and Starter Kit** (https://engage.mitre.org) — canonical Goals/Approaches/Activities, the 10-Step Process, and operation-planning worksheets.
+- **MITRE ATT&CK Navigator** — to lay out the target adversary's techniques and overlay selected Engagement Activities.
+- **MITRE D3FEND** — the `Deceive` tactic provides defensive countermeasure naming (Decoy Environment, Decoy Object, honeynet types) that complements Engage.
+- **Deception platforms / open tooling** — OpenCanary, T-Pot, Cowrie (honeypots); Canarytokens, Thinkst Canary (honeytokens); to *implement* selected Activities.
+- **SIEM/SOAR** — to route decoy telemetry to high-priority detections and automate Expose → IR hand-off.
+- **CTI platform (MISP, OpenCTI)** — to store and share the first-party intelligence produced under the Elicit goal.
+
+## Common Scenarios
+
+- **"We have honeypots but no value."** Map existing honeypots to the Expose goal, define an Operational Objective (alert latency, dwell-time reduction), and connect alerts to an IR hand-off so the deployment produces decisions, not noise.
+- **"Targeted by a specific actor."** Build the actor's ATT&CK technique set, map each to the Activity that exposes it, and prioritize the smallest set of Activities that covers the actor's likely kill chain.
+- **"Protect unpatchable legacy systems."** Use Affect Activities (Direction, Network Manipulation, decoys) to steer adversaries away from systems that cannot be remediated.
+- **"Tired of CVE whack-a-mole."** Use the Elicit goal to generate a first-party CTI feed so defense is driven by observed adversary TTPs rather than the vulnerability of the week.
+- **"Insider threat near critical data."** Seed Expose Activities (Decoy Content, Decoy Credentials, Pocket Litter) around the crown-jewel asset for high-fidelity detection of unauthorized internal access.
+
+## Output Format
+
+Produce an **Adversary Engagement Operation Plan** using `assets/template.md`, containing:
+
+1. **Strategic context** — where DD&AE fits the cyber strategy; executive sponsor; legal sign-off reference.
+2. **Engagement Goals + Operational Objectives** — each objective falsifiable and time-bound.
+3. **Threat model** — target adversary, prioritized ATT&CK techniques.
+4. **Activity selection matrix** — technique → exposed weakness → selected Engage Activity (with EAC IDs) → tactical deployment owner.
+5. **Engagement environment design** — realism, isolation/honeynet type, artifact diversity plan.
+6. **Gating criteria and rules of engagement** — blast radius, tear-down triggers, evidence handling, escalation authority.
+7. **Measurement plan** — metrics per objective (alert latency, dwell time, indicators gained, samples obtained).
+8. **After-action report** — objectives met/missed, intel produced, detections promoted to production, threat-model updates.
+
+Use `scripts/process.py` to validate technique→Activity coverage and generate the operation-plan skeleton from a threat-model input.

--- a/skills/designing-adversary-engagement-with-mitre-engage/assets/template.md
+++ b/skills/designing-adversary-engagement-with-mitre-engage/assets/template.md
@@ -1,0 +1,54 @@
+# Adversary Engagement Operation Plan
+
+> Worked example. Replace bracketed values. Do not deploy any Activity before legal sign-off and approved gating criteria.
+
+## 1. Strategic context
+- **Operation name:** Crown-Jewel Repo Watch
+- **Strategic goal (Prepare):** Reduce dwell time of unauthorized access around the source-code repository and produce first-party CTI on whoever reaches it.
+- **Where DD&AE fits the strategy:** Additive layer behind EDR + network segmentation; activates only if a primary control is bypassed.
+- **Executive sponsor:** [CISO name]
+- **Legal sign-off reference:** [Legal ticket / memo ID] — REQUIRED before deployment
+
+## 2. Engagement Goals + Operational Objectives
+| Goal (EGO) | Operational Objective (falsifiable, time-bound) |
+|---|---|
+| Expose | Alert the SOC within 5 minutes of any touch on a decoy repo credential or decoy commit. |
+| Affect | Redirect lateral-movement attempts away from 2 unpatchable build servers for the duration of the operation. |
+| Elicit | Obtain ≥10 new indicators and, if possible, one second-stage tool sample within 30 days. |
+
+## 3. Threat model
+- **Target adversary:** Suspected initial-access broker reselling dev-environment footholds.
+- **Prioritized ATT&CK techniques:** T1078 (Valid Accounts), T1552 (Unsecured Credentials), T1083 (File & Directory Discovery), T1021 (Remote Services), T1046 (Network Service Discovery).
+
+## 4. Activity selection matrix
+| ATT&CK | Weakness exposed | Engage Activity (resolve EAC on live matrix) | Deployment owner | Tactical skill |
+|---|---|---|---|---|
+| T1078 | Must test credentials | Decoy Credentials, Lures | [Detection eng.] | deploying-active-directory-honeytokens |
+| T1552 | Harvests secrets | Decoy Credentials, Artifact Diversity | [Detection eng.] | implementing-honeytokens-for-breach-detection |
+| T1083 | Enumerates files | Decoy Content, Pocket Litter | [Blue team] | deploying-decoy-files-for-ransomware-detection |
+| T1021 | Moves laterally | Network Manipulation, Decoy Systems | [Network eng.] | implementing-network-deception-with-honeypots |
+| T1046 | Scans the network | Network Diversity | [Network eng.] | implementing-network-deception-with-honeypots |
+
+## 5. Engagement environment design
+- **Honeynet type:** Connected honeynet (reachable from the dev VLAN, isolated from prod data).
+- **Realism / artifact plan:** Decoy repo with believable Pocket Litter (fake CI tokens, stale branches), Persona Creation for a fake "build-bot" account, Application Diversity to mimic the real toolchain.
+
+## 6. Gating criteria & rules of engagement
+- **Max blast radius:** Decoy VLAN only; no route to production data stores.
+- **Tear-down / IR hand-off trigger:** Any attempt to pivot toward a real prod subnet, OR collection of the second-stage sample, whichever first.
+- **Evidence handling:** Full pcap + host telemetry preserved to WORM storage; chain-of-custody log maintained.
+- **Escalation authority:** [IR lead] may halt the operation at any time.
+- **Affect Activities restricted to defender-owned network.** (Hard constraint — never act on infrastructure you do not own.)
+
+## 7. Measurement plan
+| Objective | Metric | Baseline | Result |
+|---|---|---|---|
+| Expose latency | Minutes from decoy touch to SOC alert | n/a (new) | [fill post-op] |
+| Affect redirect | Lateral attempts steered from build servers | 0 | [fill post-op] |
+| Elicit intel | New indicators / samples obtained | 0 | [fill post-op] |
+
+## 8. After-action report (complete post-operation)
+- **Objectives met/missed:** [ ]
+- **Intel produced (indicators, samples, TTPs):** [ ]
+- **Detections promoted to production:** [ ]
+- **Threat-model updates for next cycle:** [ ]

--- a/skills/designing-adversary-engagement-with-mitre-engage/references/standards.md
+++ b/skills/designing-adversary-engagement-with-mitre-engage/references/standards.md
@@ -1,0 +1,73 @@
+# MITRE Engage — Standards & Framework Reference
+
+## Primary framework
+### MITRE Engage™ v1.0
+- **Publisher**: The MITRE Corporation
+- **Version**: 1.0, last updated 2022-02-28
+- **Home**: https://engage.mitre.org
+- **Live Matrix**: https://engage.mitre.org/matrix/ (authoritative source for all Goal/Approach/Activity names and IDs)
+- **Starter Kit**: https://engage.mitre.org/starter-kit/ (10-Step Process, planning worksheets, whitepapers)
+- **Predecessor**: MITRE Shield (Engage supersedes and restructures Shield).
+- **Note**: Engage is a framework for *planning and discussing* denial, deception, and adversary engagement. It is not a tool; it provides a shared language across defenders, vendors, and decision-makers.
+
+## Engage Matrix structure
+Five columns (Goals): **Prepare · Expose · Affect · Elicit · Understand**
+- **Prepare** and **Understand** are *strategic* bookends (operation inputs and outputs).
+- **Expose**, **Affect**, **Elicit** are the three *Engagement* goals; together they form the default **Operate** view and are mapped to MITRE ATT&CK.
+
+### ID prefixes (verified from engage.mitre.org)
+| Component | Strategic prefix | Engagement prefix |
+|---|---|---|
+| Goals | SGO | EGO |
+| Approaches | SAP | EAP |
+| Activities | SAC | EAC |
+
+Always resolve specific numeric IDs (e.g., the EAC for "Decoy Credentials") against the live matrix rather than from memory.
+
+### Engagement Approaches (EAP) by Goal
+- **Expose** → Collection, Detection
+- **Affect** → Prevention, Direction, Disruption
+- **Elicit** → Reassurance, Motivation
+
+### Representative Engagement Activities (EAC), by name
+Decoy Credentials · Decoy Content · Decoy Account · Decoy Diversity · Lures · Pocket Litter ·
+Persona Creation · Artifact Diversity · Network Diversity · Application Diversity ·
+Email Manipulation · Network Manipulation · Software Manipulation · Hardware Manipulation ·
+Security Controls · Isolation · Attack Vector Migration · Peripheral Management · Baseline ·
+Network Monitoring · System Activity Monitoring · API Monitoring · Malware Detonation ·
+Burn-In · Introduced Vulnerabilities.
+
+> The matrix maps each Activity to the ATT&CK techniques whose execution exposes an adversary weakness. Use the Navigator overlay to confirm current mappings.
+
+## Operating principle: Affect is defender-network-only
+All Affect Activities are constrained to infrastructure the defender owns and controls. Acting on adversary or third-party infrastructure is out of scope and creates legal exposure.
+
+## Complementary frameworks
+
+### MITRE ATT&CK
+- https://attack.mitre.org — the technique catalog used to model the target adversary. Engagement Activities exist to exploit the weaknesses adversary techniques create.
+
+### MITRE D3FEND — `Deceive` tactic
+D3FEND (https://d3fend.mitre.org) provides defensive-technique naming that pairs with Engage. The `Deceive` tactic includes:
+- **Decoy Environment**: Connected Honeynet, Integrated Honeynet, Standalone Honeynet
+- **Decoy Object**: Decoy File, Decoy Network Resource, Decoy Persona, Decoy Public Release, Decoy Session Token, Decoy User Credential
+
+Use D3FEND honeynet types when documenting environment isolation in the operation plan:
+- **Standalone Honeynet** — fully isolated; safest; least realistic to a sophisticated adversary.
+- **Connected Honeynet** — bridged to production paths to appear reachable; moderate risk.
+- **Integrated Honeynet** — decoys interleaved with production assets; most realistic; highest operational risk and tightest gating required.
+
+## NIST CSF 2.0 alignment
+| CSF 2.0 ID | Relevance to adversary engagement |
+|---|---|
+| GV.RM-01 | Risk management objectives established — anchors the strategic Prepare goal |
+| ID.RA-01 | Vulnerabilities identified — informs which weaknesses to expose |
+| ID.IM-02 | Security testing / improvement — engagement operations validate detections |
+| DE.CM-01 | Networks monitored to find adverse events — Expose Activities feed monitoring |
+| DE.AE-02 | Potentially adverse events analyzed — triage of decoy alerts |
+
+## Legal & ethical references
+- Engagement operations interact with live adversaries; obtain written legal review before deployment.
+- Preserve evidence per the organization's incident-response and forensics procedures (chain of custody).
+- Coordinate with law enforcement engagement policy where applicable.
+- Document rules of engagement and gating criteria before any Activity is deployed.

--- a/skills/designing-adversary-engagement-with-mitre-engage/scripts/process.py
+++ b/skills/designing-adversary-engagement-with-mitre-engage/scripts/process.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+MITRE Engage operation planner.
+
+Given a threat model (a list of ATT&CK technique IDs the target adversary uses),
+this maps each technique to the Engage Activities that expose its weakness,
+reports coverage gaps, and emits an Adversary Engagement Operation Plan skeleton.
+
+The embedded ATT&CK -> Engage Activity table is a *starter* map. Reconcile against
+the live matrix at https://engage.mitre.org/matrix/ before operational use.
+
+Usage:
+    python process.py --threat-model tm.json --out plan.md
+    python process.py --list-techniques
+
+tm.json format:
+    {
+      "operation_name": "VPN-actor engagement",
+      "target_actor": "Suspected access broker",
+      "strategic_goal": "Generate first-party CTI on the VPN actor",
+      "techniques": ["T1078", "T1046", "T1021", "T1552"]
+    }
+"""
+import argparse
+import json
+import sys
+from datetime import date
+
+# Starter map: ATT&CK technique -> (short name, [candidate Engage Activities]).
+# Activities use canonical Engage names; resolve EAC numeric IDs from the live matrix.
+TECHNIQUE_TO_ACTIVITIES = {
+    "T1078": ("Valid Accounts", ["Decoy Credentials", "Lures", "Decoy Account"]),
+    "T1110": ("Brute Force", ["Decoy Credentials", "Security Controls"]),
+    "T1552": ("Unsecured Credentials", ["Decoy Credentials", "Artifact Diversity", "Pocket Litter"]),
+    "T1083": ("File and Directory Discovery", ["Decoy Content", "Pocket Litter", "Artifact Diversity"]),
+    "T1046": ("Network Service Discovery", ["Network Diversity", "Network Manipulation"]),
+    "T1021": ("Remote Services", ["Network Manipulation", "Isolation", "Decoy Content"]),
+    "T1018": ("Remote System Discovery", ["Network Diversity", "Decoy Content"]),
+    "T1057": ("Process Discovery", ["System Activity Monitoring", "Software Manipulation"]),
+    "T1071": ("Application Layer Protocol (C2)", ["Network Monitoring", "Network Manipulation"]),
+    "T1105": ("Ingress Tool Transfer", ["Malware Detonation", "Network Monitoring"]),
+    "T1190": ("Exploit Public-Facing Application", ["Introduced Vulnerabilities", "Application Diversity"]),
+    "T1059": ("Command and Scripting Interpreter", ["System Activity Monitoring", "API Monitoring"]),
+    "T1567": ("Exfiltration Over Web Service", ["Network Monitoring", "Decoy Content"]),
+}
+
+ENGAGEMENT_GOALS = ["Expose", "Affect", "Elicit"]
+
+
+def build_coverage(techniques):
+    covered, gaps = {}, []
+    for t in techniques:
+        t = t.strip().upper()
+        if t in TECHNIQUE_TO_ACTIVITIES:
+            name, acts = TECHNIQUE_TO_ACTIVITIES[t]
+            covered[t] = {"name": name, "activities": acts}
+        else:
+            gaps.append(t)
+    return covered, gaps
+
+
+def render_plan(tm, covered, gaps):
+    lines = []
+    lines.append(f"# Adversary Engagement Operation Plan: {tm.get('operation_name', 'UNNAMED')}")
+    lines.append(f"\n_Generated {date.today().isoformat()} — DRAFT, requires legal sign-off before deployment._\n")
+    lines.append("## 1. Strategic context")
+    lines.append(f"- **Target actor:** {tm.get('target_actor', 'TBD')}")
+    lines.append(f"- **Strategic goal (Prepare):** {tm.get('strategic_goal', 'TBD')}")
+    lines.append("- **Executive sponsor:** TBD")
+    lines.append("- **Legal sign-off reference:** TBD (REQUIRED before deployment)\n")
+
+    lines.append("## 2. Engagement Goals + Operational Objectives")
+    for g in ENGAGEMENT_GOALS:
+        lines.append(f"- **{g}:** define ≥1 falsifiable, time-bound objective (e.g., alert latency, dwell-time reduction, indicators gained).")
+    lines.append("")
+
+    lines.append("## 3. Activity selection matrix")
+    lines.append("| ATT&CK | Technique | Weakness → Engage Activities | Deployment owner |")
+    lines.append("|---|---|---|---|")
+    for t, info in covered.items():
+        acts = ", ".join(info["activities"])
+        lines.append(f"| {t} | {info['name']} | {acts} | TBD |")
+    if not covered:
+        lines.append("| — | — | (no mapped techniques) | — |")
+    lines.append("")
+
+    if gaps:
+        lines.append("## 3a. Coverage GAPS (no starter mapping — check live matrix)")
+        for t in gaps:
+            lines.append(f"- {t}: resolve against https://engage.mitre.org/matrix/")
+        lines.append("")
+
+    lines.append("## 4. Engagement environment design")
+    lines.append("- Honeynet type (standalone / connected / integrated): TBD")
+    lines.append("- Artifact diversity plan (Persona Creation, Pocket Litter, Artifact/Application/Network Diversity): TBD\n")
+
+    lines.append("## 5. Gating criteria & rules of engagement")
+    lines.append("- Max blast radius: TBD")
+    lines.append("- Tear-down / IR hand-off trigger: TBD")
+    lines.append("- Evidence handling & chain of custody: TBD")
+    lines.append("- Escalation authority: TBD")
+    lines.append("- Affect Activities limited to defender-owned network only (hard constraint).\n")
+
+    lines.append("## 6. Measurement plan")
+    lines.append("- Metric per objective; baseline before deployment; review cadence: TBD\n")
+
+    lines.append("## 7. After-action report (post-operation)")
+    lines.append("- Objectives met/missed, intel produced, detections promoted to production, threat-model updates: TBD")
+    return "\n".join(lines)
+
+
+def main():
+    p = argparse.ArgumentParser(description="MITRE Engage operation planner")
+    p.add_argument("--threat-model", help="Path to threat-model JSON")
+    p.add_argument("--out", help="Output markdown path (default: stdout)")
+    p.add_argument("--list-techniques", action="store_true", help="List techniques in the starter map")
+    args = p.parse_args()
+
+    if args.list_techniques:
+        for t, (name, acts) in sorted(TECHNIQUE_TO_ACTIVITIES.items()):
+            print(f"{t:8} {name:40} -> {', '.join(acts)}")
+        return
+
+    if not args.threat_model:
+        p.error("--threat-model is required (or use --list-techniques)")
+
+    with open(args.threat_model) as f:
+        tm = json.load(f)
+
+    techniques = tm.get("techniques", [])
+    if not techniques:
+        print("WARNING: threat model has no 'techniques' list", file=sys.stderr)
+
+    covered, gaps = build_coverage(techniques)
+    total = len(techniques)
+    pct = (len(covered) / total * 100) if total else 0
+    print(f"Coverage: {len(covered)}/{total} techniques mapped ({pct:.0f}%); {len(gaps)} gap(s).",
+          file=sys.stderr)
+
+    plan = render_plan(tm, covered, gaps)
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(plan + "\n")
+        print(f"Wrote operation plan -> {args.out}", file=sys.stderr)
+    else:
+        print(plan)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Add 2 skills: cloud + adversary-engagement deception

These fill deception white space the repo's existing on-prem honeypot/honeytoken
skills don't cover: a coordinating **strategy** layer and **cloud-native** decoys.

### Skills (`subdomain: deception-technology`)
1. **designing-adversary-engagement-with-mitre-engage** — plan/run/measure an
   adversary-engagement operation with the MITRE Engage Matrix + the 10-step
   operational process; maps Engage Activities to the ATT&CK techniques they expose.
   Acts as the strategy layer above the existing tactical deployment skills
   (`deploying-active-directory-honeytokens`,
   `implementing-honeytokens-for-breach-detection`,
   `deploying-decoy-files-for-ransomware-detection`,
   `implementing-network-deception-with-honeypots`) — all of which it references and
   which exist in the repo.
2. **deploying-cloud-deception-with-decoy-resources** — canary IAM keys, honey
   object-storage buckets, and decoy secrets/identities across AWS/Azure/GCP, wired
   to CloudTrail + EventBridge, Microsoft Sentinel honeytoken watchlists, and GCP
   Cloud Audit Logs, so any touch on a decoy is a near-zero-false-positive alert.

### Each skill ships
`SKILL.md`, `references/standards.md` (real citations), `scripts/process.py`
(tested CLI), `assets/template.md` (worked example), `LICENSE` (Apache-2.0).

- **Engage** `process.py`: operation planner + `--list-techniques` ATT&CK map.
- **Cloud deception** `process.py`: decoy-inventory validator that exits non-zero
  when a decoy is missing detection wiring, deny-all/least-privilege, or validation.

### Validation
- Pass `tools/validate-skill.py` and the `validate-skills.yml` CI checks (required
  frontmatter, kebab-case names, no duplicate names); `name` == directory name.
- Both scripts `py_compile` clean, `--help` exits 0, smoke-tested on pass and fail
  paths (correct exit codes). All sibling-skill references resolve.
- Plain-text status markers only (no emoji), matching the repo's house style.

### Note for the maintainer (subdomain enum)
`deception-technology` is accepted by `tools/validate-skill.py`
(`ALLOWED_SUBDOMAINS`) and already used by existing merged skills, but it is **not
listed in `CONTRIBUTING.md`'s subdomain enum** — along with several other
validator-accepted subdomains (`threat-detection`, `blockchain-security`,
`data-protection`, `firmware-analysis`, `privacy-compliance`, `purple-team`,
`supply-chain-security`, `wireless-security`, `ai-security`). The CONTRIBUTING enum
appears to have drifted behind the validator. **Would you like a small follow-up PR
to sync CONTRIBUTING.md with the validator's `ALLOWED_SUBDOMAINS`?** Happy to add it.

`index.json` is intentionally not touched — it's regenerated by `update-index.yml`
on merge to `main`.
