### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/skills/implementing-supply-chain-security-with-in-toto/references/api-reference.md
+++ b/skills/implementing-supply-chain-security-with-in-toto/references/api-reference.md
@@ -12,7 +12,7 @@
 ## Installation
 
 ```bash
-pip install in-toto securesystemslib[crypto]
+pip install in-toto 'securesystemslib[crypto]'
 ```
 
 ## CLI Commands


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `skills/implementing-supply-chain-security-with-in-toto/references/api-reference.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`