### PR TITLE
fix: resolve 5 runtime crashes in agent.py scripts

### DIFF
--- a/skills/analyzing-linux-elf-malware/scripts/agent.py
+++ b/skills/analyzing-linux-elf-malware/scripts/agent.py
@@ -124,9 +124,9 @@ def check_packing(filepath):
         indicators.append("UPX packer detected (UPX! magic)")
     if b"UPX0" in data or b"UPX1" in data:
         indicators.append("UPX section names found")
-    stdout, _, _ = subprocess.run(["upx", "-t", filepath],
-                                   capture_output=True, text=True,
-                                   stderr=subprocess.STDOUT, timeout=120).stdout, "", 0
+    proc = subprocess.run(["upx", "-t", filepath],
+                          capture_output=True, text=True, timeout=120)
+    stdout = proc.stdout
     if stdout and "packed" in stdout.lower():
         indicators.append("UPX verification confirms packing")
     return indicators

--- a/skills/configuring-snort-ids-for-intrusion-detection/scripts/agent.py
+++ b/skills/configuring-snort-ids-for-intrusion-detection/scripts/agent.py
@@ -14,7 +14,7 @@ SNORT_BIN = os.environ.get("SNORT_BIN", "/usr/local/bin/snort")
 SNORT_CONF = os.environ.get("SNORT_CONF", "/usr/local/etc/snort/snort.lua")
 RULES_DIR = os.environ.get("SNORT_RULES_DIR", "/usr/local/etc/snort/rules")
 LOG_DIR = os.environ.get("SNORT_LOG_DIR", "/var/log/snort")
-DAQ_DIR = os.environ.get("SNORT_DAQ_DIR", DAQ_DIR)
+DAQ_DIR = os.environ.get("SNORT_DAQ_DIR", "/usr/local/lib/daq")
 
 
 def check_snort_installed():

--- a/skills/deploying-ransomware-canary-files/scripts/agent.py
+++ b/skills/deploying-ransomware-canary-files/scripts/agent.py
@@ -278,7 +278,13 @@ def send_syslog_alert(alert_data, syslog_server="127.0.0.1", syslog_port=514):
         return False
 
 
-class CanaryFileHandler(FileSystemEventHandler):
+# When watchdog is not installed, FileSystemEventHandler is undefined at
+# module load; fall back to object so importing the module never raises. The
+# handler is only instantiated inside the watchdog-guarded monitoring path.
+_CanaryHandlerBase = FileSystemEventHandler if HAS_WATCHDOG else object
+
+
+class CanaryFileHandler(_CanaryHandlerBase):
     """Watchdog event handler for canary file monitoring."""
 
     def __init__(self, canary_files, config):

--- a/skills/monitoring-darkweb-sources/scripts/agent.py
+++ b/skills/monitoring-darkweb-sources/scripts/agent.py
@@ -146,7 +146,10 @@ def generate_monitoring_report(
         f"  Known Breaches Involving Domain: {len(breaches)}",
     ]
     for b in breaches[:5]:
-        lines.append(f"  - {b['name']} ({b['breach_date']}) - {b['pwn_count']:,} accounts")
+        lines.append(
+            f"  - {b.get('name', 'Unknown')} "
+            f"({b.get('breach_date', '?')}) - {b.get('pwn_count', 0):,} accounts"
+        )
 
     lines.extend([
         "",

--- a/skills/performing-log-analysis-for-forensic-investigation/scripts/agent.py
+++ b/skills/performing-log-analysis-for-forensic-investigation/scripts/agent.py
@@ -188,7 +188,8 @@ class ForensicLogAnalyzer:
         timeline_path = self.output_dir / f"{self.case_id}_timeline.csv"
         if timeline:
             with open(timeline_path, "w", newline="") as f:
-                writer = csv.DictWriter(f, fieldnames=list(timeline[0].keys()))
+                fieldnames = sorted({k for event in timeline for k in event})
+                writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
                 writer.writeheader()
                 for event in timeline[:10000]:
                     writer.writerow({k: str(v)[:200] for k, v in event.items()})


### PR DESCRIPTION
## Summary

Fixes the five reproducible runtime defects reported in #103, found by executing every `skills/*/scripts/agent.py`. Each is an independent code bug (not a missing-dependency/input/credential issue). Two of them (#1, #2) fail at **module import**, so the affected skill cannot start at all.

- **configuring-snort-ids-for-intrusion-detection** (`agent.py:17`): `DAQ_DIR` used itself as its `os.environ.get` default → `NameError` at import. Now uses a literal default (`/usr/local/lib/daq`), matching the other four vars in the same block.
- **deploying-ransomware-canary-files** (`agent.py:281`): `CanaryFileHandler` inherited `FileSystemEventHandler` at module scope → `NameError` when `watchdog` is absent (before the friendly "pip install" message). The base now falls back to `object` when watchdog is missing; the handler is only instantiated inside the existing `HAS_WATCHDOG` guard.
- **analyzing-linux-elf-malware** (`agent.py:127–129`): `subprocess.run(..., capture_output=True, stderr=subprocess.STDOUT)` raises `ValueError` unconditionally. Removed the redundant `stderr=subprocess.STDOUT` since `capture_output=True` already captures stderr.
- **monitoring-darkweb-sources** (`agent.py:149`): Hard `b['name']` key access → `KeyError` on default (no-API-key) run. Switched to `.get(...)` with defaults, consistent with the same file's existing usage elsewhere.
- **performing-log-analysis-for-forensic-investigation** (`agent.py:191/194`): CSV `fieldnames` derived from `timeline[0]` only → `ValueError` when the timeline mixes event types (syslog adds `service`, `host`, `message`). Now computes the union of all keys with `extrasaction="ignore"`.

## Test plan

- [x] Reproduced each crash before the fix; verified each runs cleanly after
- [x] `python3 -m py_compile` on all 5 files — clean
- [x] `python3 tools/validate-skill.py --all` → 817/817 PASS
- [x] Grepped repo for same crash patterns — no other instances

Closes #103

Made with [Cursor](https://cursor.com)