### PR TITLE
fix: reduce Windows Defender false positive on fileless malware skill

### DIFF
--- a/skills/detecting-fileless-malware-techniques/SKILL.md
+++ b/skills/detecting-fileless-malware-techniques/SKILL.md
@@ -49,6 +49,12 @@ mitre_attack:
 
 **Do not use** for traditional file-based malware; standard static and dynamic analysis methods are more appropriate for disk-resident malware.
 
+## Windows Defender / Antivirus False Positive
+
+Some endpoint antivirus products — notably **Windows Defender** (signature `Trojan:script/Wacatac.H!ml`) — may quarantine this skill's `SKILL.md` as malicious. This is a **known false positive**: the file intentionally documents fileless attack patterns (LOLBins, encoded PowerShell, memory YARA indicators) for defensive detection and investigation. The content is educational only; it does not execute code.
+
+**If quarantined:** restore the file from quarantine, add an exclusion for your local agent skills directory, and see [GitHub issue #100](https://github.com/mukul975/Anthropic-Cybersecurity-Skills/issues/100) for discussion. YARA strings live in `references/yara-fileless-powershell.yar` (not inline in this file) to reduce scanner triggers while preserving the rule for analysts.
+
 ## Prerequisites
 
 - Sysmon installed and configured with comprehensive logging (process creation, WMI events, registry changes)
@@ -239,22 +245,13 @@ vol3 -f memory.dmp windows.vadinfo --pid 4012 | grep -i "PAGE_EXECUTE"
 # PowerShell CLR usage (indicates .NET reflection loading)
 vol3 -f memory.dmp windows.cmdline | grep -i "powershell"
 
-# Scan for known fileless frameworks
-vol3 -f memory.dmp yarascan.YaraScan --yara-rules "
-rule Fileless_PowerShell {
-    strings:
-        \$s1 = \"System.Reflection.Assembly\" ascii wide
-        \$s2 = \"[System.Convert]::FromBase64String\" ascii wide
-        \$s3 = \"Invoke-Expression\" ascii wide
-        \$s4 = \"DownloadString\" ascii wide
-    condition:
-        2 of them
-}
-"
+# Scan for known fileless frameworks (rule file avoids AV false positives on SKILL.md)
+vol3 -f memory.dmp yarascan.YaraScan --yara-file references/yara-fileless-powershell.yar
 
 # Extract PowerShell command history from memory
 vol3 -f memory.dmp windows.cmdline
-strings memory.dmp | grep -i "invoke-\|iex \|downloadstring\|-encodedcommand"
+# Search memory strings for common fileless indicators (encoded commands, cradles, reflection)
+strings memory.dmp | grep -iE 'encodedcommand|downloadstring|invoke-expression|\.reflection\.'
 ```
 
 ### Step 5: Build Comprehensive Detection Rules
@@ -400,7 +397,7 @@ Filter Name:      WindowsUpdateCheck
 Filter Query:     SELECT * FROM __InstanceModificationEvent WITHIN 300
                   WHERE TargetInstance ISA 'Win32_PerfFormattedData_PerfOS_System'
 Consumer:         CommandLineEventConsumer
-Command:          powershell.exe -nop -w hidden -enc JABjAGwAaQBlAG4AdAA...
+Command:          powershell.exe -nop -w hidden -enc <BASE64_UTF16LE_PAYLOAD>
 
 DECODED PAYLOAD
 [Layer 1] Base64 UTF-16LE decode

--- a/skills/detecting-fileless-malware-techniques/SKILL.md
+++ b/skills/detecting-fileless-malware-techniques/SKILL.md
@@ -245,8 +245,9 @@ vol3 -f memory.dmp windows.vadinfo --pid 4012 | grep -i "PAGE_EXECUTE"
 # PowerShell CLR usage (indicates .NET reflection loading)
 vol3 -f memory.dmp windows.cmdline | grep -i "powershell"
 
-# Scan for known fileless frameworks (rule file avoids AV false positives on SKILL.md)
-vol3 -f memory.dmp yarascan.YaraScan --yara-file references/yara-fileless-powershell.yar
+# Scan for known fileless frameworks
+# YARA rule lives in references/yara-fileless-powershell.yar (kept separate to reduce AV false positives)
+vol3 -f memory.dmp yarascan.YaraScan --yara-file /path/to/yara-fileless-powershell.yar
 
 # Extract PowerShell command history from memory
 vol3 -f memory.dmp windows.cmdline

--- a/skills/detecting-fileless-malware-techniques/references/api-reference.md
+++ b/skills/detecting-fileless-malware-techniques/references/api-reference.md
@@ -61,6 +61,8 @@ vol3 -f memory.dmp windows.malfind --dump --pid 1234
 
 ## Suspicious PowerShell Indicators
 
+Detection patterns to search for in Script Block Logging (Event ID 4104) and memory strings. See `yara-fileless-powershell.yar` in this directory for a Volatility YARA rule covering the same indicators.
+
 ```
 -enc / -EncodedCommand    → Base64-encoded command
 IEX / Invoke-Expression   → Dynamic code execution

--- a/skills/detecting-fileless-malware-techniques/references/yara-fileless-powershell.yar
+++ b/skills/detecting-fileless-malware-techniques/references/yara-fileless-powershell.yar
@@ -1,0 +1,13 @@
+// YARA rule for Volatility yarascan — fileless PowerShell indicators in memory.
+// Stored separately from SKILL.md to reduce antivirus false positives on the skill file.
+// See GitHub issue #100.
+
+rule Fileless_PowerShell {
+    strings:
+        $s1 = "System.Reflection.Assembly" ascii wide
+        $s2 = "[System.Convert]::FromBase64String" ascii wide
+        $s3 = "Invoke-Expression" ascii wide
+        $s4 = "DownloadString" ascii wide
+    condition:
+        2 of them
+}


### PR DESCRIPTION
## Summary

Addresses **#100** — Windows Defender quarantines `detecting-fileless-malware-techniques/SKILL.md` as `Trojan:script/Wacatac.H!ml`. The skill content is defensive/educational; the detection is a false positive caused by literal malware-pattern strings embedded in documentation.

**Scope and limitations:** This PR reduces the triggering surface by removing the highest-signal tokens (inline YARA rules with literal malware strings, a Base64-encoded PowerShell payload sample). However, `SKILL.md` intentionally retains educational references to LOLBin abuse patterns, `Invoke-Mimikatz`, CobaltStrike, and `AMSI bypass` — these are core to the skill's purpose and cannot be sanitized without gutting the content. This PR may reduce but not eliminate false positives. The primary deliverable is the **discoverability section** so users who hit this know it's a known issue and how to resolve it.

Changes:
- Add a **Windows Defender / Antivirus False Positive** section so future searchers find guidance (links to #100, restore/exclusion steps)
- Move inline Volatility YARA rule to `references/yara-fileless-powershell.yar` (preserves the rule for analysts, reduces scanner hits on `SKILL.md`)
- Replace literal Base64-encoded PowerShell sample with `<BASE64_UTF16LE_PAYLOAD>` placeholder in the worked report
- Soften memory `strings` grep examples

## Test plan

- [x] `python3 tools/validate-skill.py skills/detecting-fileless-malware-techniques` → PASS
- [x] `python3 tools/validate-skill.py --all` → 817/817 PASS
- [ ] Windows Defender re-scan on Windows (cannot verify in Linux CI — would appreciate confirmation from a Windows user)

Mitigates #100