### PR TITLE
Fix always-empty timestamp in performing-malware-ioc-extraction agent.py report

### DIFF
--- a/skills/performing-malware-ioc-extraction/scripts/agent.py
+++ b/skills/performing-malware-ioc-extraction/scripts/agent.py
@@ -5,6 +5,7 @@ import json
 import argparse
 import re
 import hashlib
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -102,7 +103,7 @@ def generate_ioc_report(file_path, output=None):
     hashes = hash_file(file_path)
     strings = extract_strings(file_path)
     report = {
-        "generated": datetime.utcnow().isoformat() if "datetime" in dir() else "",
+        "generated": datetime.now(timezone.utc).isoformat(),
         "file_info": hashes,
         "strings_analysis": {
             "total": strings["total_strings"],


### PR DESCRIPTION
## What changed and why

`skills/performing-malware-ioc-extraction/scripts/agent.py`'s `generate_ioc_report()` sets the `"generated"` field with:
```python
"generated": datetime.utcnow().isoformat() if "datetime" in dir() else "",
```
`datetime` is never imported anywhere in this file, and `dir()` with no arguments only inspects local scope names -- so this guard is always `False`. Every generated report has `"generated": ""` instead of a real timestamp.

## Fix

Imported `datetime`/`timezone` at the top and call `datetime.now(timezone.utc).isoformat()` directly (the non-deprecated replacement for `utcnow()`, since Python 3.12 deprecates `datetime.utcnow()`).

## How to test

```bash
python3 -m py_compile skills/performing-malware-ioc-extraction/scripts/agent.py
python3 skills/performing-malware-ioc-extraction/scripts/agent.py --help

echo "test file" > /tmp/sample.bin
python3 skills/performing-malware-ioc-extraction/scripts/agent.py report --file /tmp/sample.bin
# "generated" field is now a real ISO 8601 UTC timestamp, e.g.
# "2026-07-17T14:46:03.178652+00:00", instead of ""
```

## Breaking changes

None -- `"generated"` was already a string field; it now just contains a real value instead of always being empty.