### PR TITLE
Add skill: extracting-and-analyzing-embedded-firmware-with-binwalk

### DIFF
--- a/skills/extracting-and-analyzing-embedded-firmware-with-binwalk/SKILL.md
+++ b/skills/extracting-and-analyzing-embedded-firmware-with-binwalk/SKILL.md
@@ -1,0 +1,156 @@
+\---
+
+name: extracting-and-analyzing-embedded-firmware-with-binwalk
+
+description: >-
+
+&#x20; Extract, unpack, and analyze binary firmware images from IoT, embedded, and network hardware using Binwalk
+
+&#x20; to identify embedded Linux filesystems, hardcoded secrets, and vulnerable binaries.
+
+domain: cybersecurity
+
+subdomain: hardware-firmware-security
+
+tags: \[hardware, firmware, binwalk, embedded-security, reverse-engineering, iot, squashfs, static-analysis]
+
+atlas\_techniques: \[]
+
+d3fend\_techniques: \[D3-FA]
+
+nist\_ai\_rmf: \[]
+
+nist\_csf: \[ID.RA-01, PR.DS-01, DE.CM-01]
+
+version: "1.0"
+
+author: praveshuma
+
+license: Apache-2.0
+
+\---
+
+
+
+\## When to Use
+
+Trigger this skill when:
+
+\- Analyzing raw monolithic firmware images (`.bin`, `.img`, `.chk`, `.pkg`) extracted from IoT or embedded devices.
+
+\- Unpacking compressed embedded filesystems (SquashFS, CRAMFS, JFFS2, UBIFS) to inspect system files.
+
+\- Auditing firmware images for static vulnerability analysis, hardcoded SSH keys, API tokens, or backdoor binaries.
+
+
+
+\## Prerequisites
+
+\- Linux analysis environment with `binwalk` v3+ or `binwalk` v2 with extraction utilities installed.
+
+\- Decompression and filesystem utilities (`sasquatch`, `squashfs-tools`, `ubireader`, `tar`, `gzip`, `p7zip`).
+
+\- Command-line utilities for static file inspection (`strings`, `grep`, `file`).
+
+
+
+\## Workflow
+
+
+
+\### Step 1: Scan Firmware Magic Bytes and Entropy
+
+Perform an initial signature scan to map header offsets and measure overall firmware entropy to check for encryption or compression.
+
+
+
+```bash
+
+\# Scan firmware for magic byte signatures and offsets
+
+binwalk target\_firmware.bin
+
+
+
+\# Generate entropy plot/analysis to identify encrypted vs compressed regions
+
+binwalk -E target\_firmware.bin
+
+
+
+Step 2: Recursively Extract Embedded Filesystem Components
+
+Extract all detected compressed blocks and embedded filesystems recursively into a structured directory.
+
+
+
+\# Perform automated recursive extraction (-e for extract, -M for recursive scan)
+
+binwalk -e -M target\_firmware.bin
+
+
+
+\# Navigate to the extracted filesystem directory
+
+cd \_target\_firmware.bin.extracted/
+
+ls -la
+
+
+
+Step 3: Analyze Extracted Root Filesystem for Hardcoded Secrets.
+
+Search through the extracted root directory structure (squashfs-root, rootfs, etc.) for hardcoded credentials, configuration files, and private keys. 
+
+
+
+\# Search for private SSH keys, SSL certificates, and credentials
+
+find . -type f \\( -name "\*.pem" -o -name "\*.key" -o -name "\*.crt" \\)
+
+
+
+\# Search shadow and passwd files for embedded default user hashes
+
+cat etc/shadow etc/passwd 2>/dev/null
+
+
+
+\# Scan configuration scripts for hardcoded API keys or backdoor parameters
+
+grep -riE "(password|secret|token|api\_key|admin)" etc/ www/ usr/lib/ 2>/dev/null
+
+
+
+Step 4: Identify Outdated Binaries and Web Management Services.
+
+Locate web server executables, CGI scripts, and network services to flag potential vulnerability targets for dynamic analysis.
+
+
+
+\# Find web server executables (e.g., lighttpd, httpd, boa, goahead)
+
+find . -type f -name "\*httpd\*" -o -name "\*boa\*" -o -name "\*lighttpd\*"
+
+
+
+\# Check binary dependencies and shared libraries
+
+file bin/\* sbin/\* usr/bin/\* 2>/dev/null | head -n 20
+
+
+
+\----------------
+
+Verification:
+
+Confirm successful extraction by verifying that \_target\_firmware.bin.extracted/ contains accessible directory trees (e.g., etc/, bin/, usr/).
+
+
+
+Run file on extracted executables inside bin/ to verify target architecture (e.g., MIPS, ARM, x86\_64).
+
+
+
+Validate that non-zero file sizes are extracted and readable without corrupted headers.
+

--- a/skills/extracting-and-analyzing-embedded-firmware-with-binwalk/references/standards.md
+++ b/skills/extracting-and-analyzing-embedded-firmware-with-binwalk/references/standards.md
@@ -1,0 +1,58 @@
+Create `skills/extracting-and-analyzing-embedded-firmware-with-binwalk/references/standards.md` and add the following:
+
+
+
+```markdown
+
+\# Framework Mappings: Extracting and Analyzing Embedded Firmware with Binwalk
+
+
+
+\## MITRE ATT\&CK v19.1
+
+\- \*\*TA0001 - Initial Access\*\*
+
+&#x20; - \[T1195.002 - Supply Chain Compromise: Compromise Software Supply Chain](https://attack.mitre.org/techniques/T1195/002/): Identifies pre-installed vulnerabilities or backdoors in vendor-provided firmware images.
+
+\- \*\*TA0006 - Credential Access\*\*
+
+&#x20; - \[T1552.001 - Unsecured Credentials: Credentials In Files](https://attack.mitre.org/techniques/T1552/001/): Extracts hardcoded credentials, default root passwords, and private SSH keys from embedded filesystems.
+
+\- \*\*TA0003 - Persistence\*\*
+
+&#x20; - \[T1542.001 - Pre-OS Boot: System Firmware](https://attack.mitre.org/techniques/T1542/001/): Inspects low-level firmware components for persistent malicious implants or modified boot scripts.
+
+
+
+\## NIST CSF 2.0
+
+\- \*\*Identify (ID)\*\*
+
+&#x20; - \*\*ID.RA-01\*\*: Vulnerabilities in hardware, software, and firmware assets are identified and documented.
+
+\- \*\*Protect (PR)\*\*
+
+&#x20; - \*\*PR.DS-01\*\*: Data-at-rest protection and hardcoded secret exposure are evaluated across embedded hardware.
+
+\- \*\*Detect (DE)\*\*
+
+&#x20; - \*\*DE.CM-01\*\*: Hardware assets and underlying software components are monitored for unauthorized modifications.
+
+
+
+\## MITRE D3FEND v1.3
+
+\- \*\*D3-FA (Firmware Analysis)\*\*: Extracting and inspecting hardware firmware binaries to analyze security controls, embedded filesystems, and vulnerability exposures.
+
+
+
+\## NIST AI RMF 1.0
+
+\- \*N/A (Non-AI specialized hardware control)\*
+
+
+
+\## MITRE ATLAS v5.4
+
+\- \*N/A (Non-AI specialized hardware control)\*
+


### PR DESCRIPTION
Adds a new hardware & firmware security skill for scanning, extracting, and analyzing embedded firmware images (MIPS/ARM/x86) using Binwalk. Includes static secret hunting workflows and framework mappings for MITRE ATT&CK, NIST CSF 2.0, and MITRE D3FEND.