### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -346,7 +346,7 @@ Toutes les plateformes supportant le standard agentskills.io peuvent charger ces
 
 ## Historique des étoiles
 
-![Star History Chart](https://api.star-history.com/svg?repos=mukul975/Anthropic-Cybersecurity-Skills&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=mukul975/Anthropic-Cybersecurity-Skills&type=Date)
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -363,11 +363,11 @@ All platforms that support the [agentskills.io](https://agentskills.io) standard
 
 ## Star history
 
-<a href="https://star-history.com/#mukul975/Anthropic-Cybersecurity-Skills&Date">
+<a href="https://star-history.dera.page/#mukul975/Anthropic-Cybersecurity-Skills&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=mukul975/Anthropic-Cybersecurity-Skills&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=mukul975/Anthropic-Cybersecurity-Skills&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=mukul975/Anthropic-Cybersecurity-Skills&type=Date" width="100%" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=mukul975/Anthropic-Cybersecurity-Skills&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=mukul975/Anthropic-Cybersecurity-Skills&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=mukul975/Anthropic-Cybersecurity-Skills&type=Date" width="100%" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart is currently broken and shows nothing, because it relies on the GitHub stargazer API which now restricts this kind of usage. This PR switches the chart to a working alternative so the stargazer history renders correctly again. The change applies to both the English and the French README.